### PR TITLE
Add ReorgEnd event to interfaces

### DIFF
--- a/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHub.cs
+++ b/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHub.cs
@@ -16,5 +16,7 @@ namespace Nekoyume.Shared.Hubs
         Task UpdateTipAsync(long index);
 
         Task ReportReorgAsync(byte[] oldTip, byte[] newTip, byte[] branchpoint);
+        
+        Task ReportReorgEndAsync(byte[] oldTip, byte[] newTip, byte[] branchpoint);
     }
 }

--- a/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHubReceiver.cs
+++ b/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHubReceiver.cs
@@ -9,5 +9,7 @@
         void OnTipChanged(long index);
 
         void OnReorged(byte[] oldTip, byte[] newTip, byte[] branchpoint);
+
+        void OnReorgEnd(byte[] oldTip, byte[] newTip, byte[] branchpoint);
     }
 }


### PR DESCRIPTION
Implements newly added `IRenderer.RenderReorgEnd()` event. Please see also https://github.com/planetarium/lib9c/pull/67