### PR TITLE
Enrich block render event

### DIFF
--- a/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHub.cs
+++ b/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHub.cs
@@ -13,7 +13,7 @@ namespace Nekoyume.Shared.Hubs
 
         Task BroadcastUnrenderAsync(byte[] encoded);
 
-        Task UpdateTipAsync(long index);
+        Task BroadcastRenderBlockAsync(byte[] oldTip, byte[] newTip);
 
         Task ReportReorgAsync(byte[] oldTip, byte[] newTip, byte[] branchpoint);
         

--- a/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHubReceiver.cs
+++ b/NineChronicles.RPC.Shared/Hubs/IActionEvaluationHubReceiver.cs
@@ -6,7 +6,7 @@
         
         void OnUnrender(byte[] evaluation);
 
-        void OnTipChanged(long index);
+        void OnRenderBlock(byte[] oldTip, byte[] newTip);
 
         void OnReorged(byte[] oldTip, byte[] newTip, byte[] branchpoint);
 


### PR DESCRIPTION
Instead of just reporting `long`-typed index of tip, now will report serialized `oldTip` and `newTip`.

Also renamed from `OnTipChanged` to `OnRenderBlock`.