### PR TITLE
Add an RPCException.InvalidRenderException enum field

### DIFF
--- a/NineChronicles.RPC.Shared/Exceptions/RPCException.cs
+++ b/NineChronicles.RPC.Shared/Exceptions/RPCException.cs
@@ -8,5 +8,8 @@ namespace NineChronicles.RPC.Shared.Exceptions
         NetworkException = 0x01,
         
         ChainTooLowException = 0x02,
+
+        // Used by ValidatingActionRenderer<T> (i.e., --strict-rendering):
+        InvalidRenderException = 0x03,
     }
 }


### PR DESCRIPTION
Added an `RPCException.InvalidRenderException` enum field to represent Libplanet's [`InvalidRenderException<T>`][1].

[1]: https://docs.libplanet.io/main/api/Libplanet.Blockchain.Renderers.Debug.InvalidRenderException-1.html